### PR TITLE
Fix Scaladoc links

### DIFF
--- a/api_mappings.sbt
+++ b/api_mappings.sbt
@@ -1,0 +1,23 @@
+autoAPIMappings := true
+
+val bootClasspath = System.getProperty("sun.boot.class.path").split(":").map(file(_))
+
+apiMappings ++= {
+  val cp  = (fullClasspath in Compile).value
+
+  def findManagedDependency(organization: String, name: String): File =
+    ( for {
+      entry <- cp
+      module <- entry.get(moduleID.key)
+      if module.organization == organization
+      if module.name.startsWith(name)
+        jarFile = entry.data
+    } yield jarFile
+  ).head
+
+  Map(
+    bootClasspath.find(_.getPath.endsWith("rt.jar")).get -> url("http://docs.oracle.com/javase/8/docs/api/"),
+    findManagedDependency("com.github.ben-manes.caffeine", "caffeine") ->
+      url("http://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/2.2.3")
+  )
+}

--- a/src/main/scala/com/github/blemale/scaffeine/LoadingCache.scala
+++ b/src/main/scala/com/github/blemale/scaffeine/LoadingCache.scala
@@ -14,7 +14,7 @@ class LoadingCache[K, V](override val underlying: CaffeineLoadingCache[K, V]) ex
    * Returns the value associated with `key` in this cache, obtaining that value from
    * `loader` if necessary.
    * <p>
-   * If another call to [[LoadingCache.get]] is currently loading the value for `key`, this thread
+   * If another call to this method is currently loading the value for `key`, this thread
    * simply waits for that thread to finish and returns its loaded value. Note that multiple threads
    * can concurrently load values for distinct keys.
    *

--- a/src/main/scala/com/github/blemale/scaffeine/Scaffeine.scala
+++ b/src/main/scala/com/github/blemale/scaffeine/Scaffeine.scala
@@ -34,7 +34,7 @@ object Scaffeine {
   /**
    * Constructs a new `Scaffeine` instance with the settings specified in `spec`.
    *
-   * @param spec a [[String]] in the format specified by
+   * @param spec a [[java.lang.String]] in the format specified by
    *             [[com.github.benmanes.caffeine.cache.CaffeineSpec]]
    * @return a new instance with the specification's settings
    */
@@ -278,7 +278,7 @@ case class Scaffeine[K, V](underlying: Caffeine[K, V]) {
     ))
 
   /**
-   * Builds a cache, which either returns a [[Future]] already loaded or currently
+   * Builds a cache, which either returns a [[scala.concurrent.Future]] already loaded or currently
    * computing the value for a given key, or atomically computes the value asynchronously through a
    * supplied mapping function or the supplied `loader`. If the asynchronous computation
    * fails then the entry will be automatically removed. Note that multiple threads can
@@ -306,7 +306,7 @@ case class Scaffeine[K, V](underlying: Caffeine[K, V]) {
     ))
 
   /**
-   * Builds a cache, which either returns a [[Future]] already loaded or currently
+   * Builds a cache, which either returns a [[scala.concurrent.Future]] already loaded or currently
    * computing the value for a given key, or atomically computes the value asynchronously through a
    * supplied mapping function or the supplied async `loader`. If the asynchronous
    * computation fails then the entry will be automatically removed.


### PR DESCRIPTION
Still not perfect, as links to Caffeine are broken.
Quite possibly because Scaffeine reuses the same class names as Caffeine :/

fixes #1 