### PR TITLE
Compile to scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ startYear := Some(2016)
 
 homepage := Some(url("https://github.com/blemale/scaffeine"))
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 libraryDependencies ++=
   Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,8 +4,8 @@ object Dependencies {
   val CaffeineVersion = "2.3.3"
 
   val Caffeine = "com.github.ben-manes.caffeine" % "caffeine" % CaffeineVersion
-  val Java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.7.0"
+  val Java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0"
   val Jsr305 = "com.google.code.findbugs" % "jsr305" % "3.0.1"
-  val Scalactic = "org.scalactic" %% "scalactic" % "2.2.6"
-  val Scalatest = "org.scalatest" %% "scalatest" % "2.2.6"
+  val Scalactic = "org.scalactic" %% "scalactic" % "3.0.1"
+  val Scalatest = "org.scalatest" %% "scalatest" % "3.0.1"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 

--- a/release.sbt
+++ b/release.sbt
@@ -17,6 +17,9 @@ releaseProcess := Seq[ReleaseStep](
 
 useGpg := true
 
+releaseCrossBuild := true
+crossScalaVersions := Seq("2.11.8", "2.12.0")
+
 TravisCredentials.updateCredentials()
 
 pomExtra in Global := {

--- a/src/test/scala/com/github/blemale/scaffeine/AsyncLoadingCacheSpec.scala
+++ b/src/test/scala/com/github/blemale/scaffeine/AsyncLoadingCacheSpec.scala
@@ -1,13 +1,13 @@
 package com.github.blemale.scaffeine
 
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ OptionValues, ShouldMatchers, WordSpec }
+import org.scalatest.{ Matchers, OptionValues, WordSpec }
 
 import scala.concurrent.Future
 
 class AsyncLoadingCacheSpec
     extends WordSpec
-    with ShouldMatchers
+    with Matchers
     with ScalaFutures
     with OptionValues {
 

--- a/src/test/scala/com/github/blemale/scaffeine/CacheSpec.scala
+++ b/src/test/scala/com/github/blemale/scaffeine/CacheSpec.scala
@@ -6,7 +6,7 @@ import scala.concurrent.ExecutionContext
 
 class CacheSpec
     extends WordSpec
-    with ShouldMatchers
+    with Matchers
     with OptionValues {
 
   "Cache" should {

--- a/src/test/scala/com/github/blemale/scaffeine/LoadingCacheSpec.scala
+++ b/src/test/scala/com/github/blemale/scaffeine/LoadingCacheSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest._
 
 class LoadingCacheSpec
     extends WordSpec
-    with ShouldMatchers
+    with Matchers
     with OptionValues {
 
   "LoadingCache" should {

--- a/src/test/scala/com/github/blemale/scaffeine/RemovalListenerSpec.scala
+++ b/src/test/scala/com/github/blemale/scaffeine/RemovalListenerSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest._
 
 class RemovalListenerSpec
     extends WordSpec
-    with ShouldMatchers {
+    with Matchers {
 
   class StubListener extends ((String, String, RemovalCause) => Unit) {
     val callCounter = new AtomicInteger

--- a/src/test/scala/com/github/blemale/scaffeine/ScaffeineSpec.scala
+++ b/src/test/scala/com/github/blemale/scaffeine/ScaffeineSpec.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.Executor
 
 import com.github.benmanes.caffeine.cache.stats.StatsCounter
 import com.github.benmanes.caffeine.cache._
-import org.scalatest.{ PrivateMethodTester, ShouldMatchers, WordSpec }
+import org.scalatest.{ PrivateMethodTester, Matchers, WordSpec }
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -12,7 +12,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 
 class ScaffeineSpec
     extends WordSpec
-    with ShouldMatchers
+    with Matchers
     with PrivateMethodTester {
 
   "Scaffeine" should {

--- a/src/test/scala/com/github/blemale/scaffeine/WeigherSpec.scala
+++ b/src/test/scala/com/github/blemale/scaffeine/WeigherSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest._
 
 class WeigherSpec
     extends WordSpec
-    with ShouldMatchers
+    with Matchers
     with OptionValues {
 
   "Cache" should {

--- a/src/test/scala/com/github/blemale/scaffeine/example/AsyncLoadingCacheExample.scala
+++ b/src/test/scala/com/github/blemale/scaffeine/example/AsyncLoadingCacheExample.scala
@@ -1,13 +1,13 @@
 package com.github.blemale.scaffeine.example
 
-import org.scalatest.{ FlatSpec, ShouldMatchers }
+import org.scalatest.{ FlatSpec, Matchers }
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Future
 
 class AsyncLoadingCacheExample
     extends FlatSpec
-    with ShouldMatchers
+    with Matchers
     with ScalaFutures {
 
   "AsyncLoadingCache" should "be created from Scaffeine builder with synchronous loader" in {

--- a/src/test/scala/com/github/blemale/scaffeine/example/CacheExample.scala
+++ b/src/test/scala/com/github/blemale/scaffeine/example/CacheExample.scala
@@ -1,10 +1,10 @@
 package com.github.blemale.scaffeine.example
 
-import org.scalatest.{ FlatSpec, ShouldMatchers }
+import org.scalatest.{ FlatSpec, Matchers }
 
 class CacheExample
     extends FlatSpec
-    with ShouldMatchers {
+    with Matchers {
 
   "Cache" should "be created from Scaffeine builder" in {
     import com.github.blemale.scaffeine.{ Cache, Scaffeine }

--- a/src/test/scala/com/github/blemale/scaffeine/example/LoadingCacheExample.scala
+++ b/src/test/scala/com/github/blemale/scaffeine/example/LoadingCacheExample.scala
@@ -1,10 +1,10 @@
 package com.github.blemale.scaffeine.example
 
-import org.scalatest.{ FlatSpec, ShouldMatchers }
+import org.scalatest.{ FlatSpec, Matchers }
 
 class LoadingCacheExample
     extends FlatSpec
-    with ShouldMatchers {
+    with Matchers {
 
   "LoadingCache" should "be created from Scaffeine builder" in {
     import com.github.blemale.scaffeine.{ LoadingCache, Scaffeine }


### PR DESCRIPTION
Enable cross compilation for scala 2.11.8 and 2.12.0.
Update needed dependencies to enable scala 2.12 compilation.

Fix #8