### PR TITLE
Fix sbt-release process

### DIFF
--- a/release.sbt
+++ b/release.sbt
@@ -11,7 +11,7 @@ releaseProcess := Seq[ReleaseStep](
   ReleaseStep(action = Command.process("publishSigned", _), enableCrossBuild = true),
   setNextVersion,
   commitNextVersion,
-  ReleaseStep(action = Command.process("sonatypeReleaseAll", _), enableCrossBuild = true),
+  ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
   pushChanges
 )
 


### PR DESCRIPTION
When cross build is enabled for `sonatypeReleaseAll` step, the process
fails because it tries to close twice the sonatype repo.