### PR TITLE
bump caffeine version to 2.6.1 and sbt version to 0.13.16

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val CaffeineVersion = "2.5.6"
+  val CaffeineVersion = "2.6.1"
 
   val Caffeine = "com.github.ben-manes.caffeine" % "caffeine" % CaffeineVersion
   val Java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 0.13.16


### PR DESCRIPTION
I've bumped the caffeine version to 2.6.1 and all tests pass. While I was at it, I also updated sbt from 0.13.8 -> 0.13.16.

I haven't changed the version of scaffeine itself because I'm not sure what the next version should be.