### PR TITLE
Remove useless ExecutionContext in AsyncLoadingCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ So this is the thinner wrapper we can came with to make Caffeine easy and idioma
 "AsyncLoadingCache" should "be created from Scaffeine builder with asynchronous loader" in {
     import com.github.blemale.scaffeine.{ AsyncLoadingCache, Scaffeine }
     import scala.concurrent.duration._
-    import scala.concurrent.ExecutionContext.Implicits.global
 
     val cache: AsyncLoadingCache[Int, String] =
       Scaffeine()

--- a/src/main/scala/com/github/blemale/scaffeine/AsyncLoadingCache.scala
+++ b/src/main/scala/com/github/blemale/scaffeine/AsyncLoadingCache.scala
@@ -4,7 +4,7 @@ import com.github.benmanes.caffeine.cache.{ AsyncLoadingCache => CaffeineAsyncLo
 
 import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 object AsyncLoadingCache {
   def apply[K, V](asyncLoadingCache: CaffeineAsyncLoadingCache[K, V]): AsyncLoadingCache[K, V] =
@@ -12,7 +12,7 @@ object AsyncLoadingCache {
 }
 
 class AsyncLoadingCache[K, V](override val underlying: CaffeineAsyncLoadingCache[K, V]) extends AsyncCache[K, V](underlying) {
-  private[this] implicit val ec = DirectExecutionContext
+  private[this] implicit val ec: ExecutionContext = DirectExecutionContext
 
   /**
    * Returns the future associated with `key` in this cache, obtaining that value from

--- a/src/test/scala/com/github/blemale/scaffeine/AsyncLoadingCacheSpec.scala
+++ b/src/test/scala/com/github/blemale/scaffeine/AsyncLoadingCacheSpec.scala
@@ -57,7 +57,6 @@ class AsyncLoadingCacheSpec
 
     "created with asynchronous loader" should {
       "get or load value" in {
-        import scala.concurrent.ExecutionContext.Implicits.global
         val cache = Scaffeine().buildAsyncFuture[String, String]((key: String) => Future.successful("loaded"))
 
         cache.put("foo", Future.successful("present"))
@@ -69,7 +68,6 @@ class AsyncLoadingCacheSpec
       }
 
       "get or load all given values" in {
-        import scala.concurrent.ExecutionContext.Implicits.global
         val cache = Scaffeine().buildAsyncFuture[String, String]((key: String) => Future.successful("loaded"))
 
         cache.put("foo", Future.successful("present"))
@@ -79,7 +77,6 @@ class AsyncLoadingCacheSpec
       }
 
       "get or bulk load all given values" in {
-        import scala.concurrent.ExecutionContext.Implicits.global
         val cache = Scaffeine().buildAsyncFuture[String, String](
           (key: String) => Future.successful("loaded"),
           allLoader = Some((keys: Iterable[String]) => Future.successful(keys.map(_ -> "bulked").toMap))

--- a/src/test/scala/com/github/blemale/scaffeine/CacheSpec.scala
+++ b/src/test/scala/com/github/blemale/scaffeine/CacheSpec.scala
@@ -2,8 +2,6 @@ package com.github.blemale.scaffeine
 
 import org.scalatest._
 
-import scala.concurrent.ExecutionContext
-
 class CacheSpec
   extends WordSpec
   with Matchers

--- a/src/test/scala/com/github/blemale/scaffeine/ScaffeineSpec.scala
+++ b/src/test/scala/com/github/blemale/scaffeine/ScaffeineSpec.scala
@@ -6,7 +6,6 @@ import com.github.benmanes.caffeine
 import com.github.benmanes.caffeine.cache.stats.StatsCounter
 import org.scalatest.{ Matchers, PrivateMethodTester, WordSpec }
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 

--- a/src/test/scala/com/github/blemale/scaffeine/example/AsyncLoadingCacheExample.scala
+++ b/src/test/scala/com/github/blemale/scaffeine/example/AsyncLoadingCacheExample.scala
@@ -1,7 +1,7 @@
 package com.github.blemale.scaffeine.example
 
-import org.scalatest.{ FlatSpec, Matchers }
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ FlatSpec, Matchers }
 
 import scala.concurrent.Future
 
@@ -12,6 +12,7 @@ class AsyncLoadingCacheExample
 
   "AsyncLoadingCache" should "be created from Scaffeine builder with synchronous loader" in {
     import com.github.blemale.scaffeine.{ AsyncLoadingCache, Scaffeine }
+
     import scala.concurrent.duration._
 
     val cache: AsyncLoadingCache[Int, String] =
@@ -28,8 +29,8 @@ class AsyncLoadingCacheExample
 
   "AsyncLoadingCache" should "be created from Scaffeine builder with asynchronous loader" in {
     import com.github.blemale.scaffeine.{ AsyncLoadingCache, Scaffeine }
+
     import scala.concurrent.duration._
-    import scala.concurrent.ExecutionContext.Implicits.global
 
     val cache: AsyncLoadingCache[Int, String] =
       Scaffeine()


### PR DESCRIPTION
Fix #47