### PR TITLE
Use openjdk 8 on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ scala:
 - 2.11.7
 
 jdk:
-- oraclejdk8
+- openjdk8
 
 cache:
   directories:


### PR DESCRIPTION
Oracle Jdk 8 seems to be not available anymore on TravisCI