### PR TITLE
Add cross build for Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           java-version: zulu@1.11
       - run: sbt ++${{ matrix.scala }} clean scalafmtSbtCheck scalafmtCheck test doc
         if: startsWith(matrix.scala, '3')
-      - run: sbt ++{{ matrix.scala }} clean scalafmtSbtCheck scalafmtCheck coverage test doc coverageReport coveralls
+      - run: sbt ++${{ matrix.scala }} clean scalafmtSbtCheck scalafmtCheck coverage test doc coverageReport coveralls
         if: startsWith(matrix.scala, '2')
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,18 @@ on: [push,pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        scala: ["2.12.14", "2.13.6", "3.0.1"]
     steps:
       - uses: actions/checkout@v2
       - uses: coursier/cache-action@v6
       - uses: olafurpg/setup-scala@v11
         with:
           java-version: zulu@1.11
-      - run: sbt clean scalafmtSbtCheck scalafmtCheck coverage +test +doc
-      - run: sbt coverageReport coveralls
+      - run: sbt ++{{ matrix.scala }} clean scalafmtSbtCheck scalafmtCheck test doc
+        if: startsWith(matrix.scala, '3')
+      - run: sbt ++{{ matrix.scala }} clean scalafmtSbtCheck scalafmtCheck coverage test doc coverageReport coveralls
+        if: startsWith(matrix.scala, '2')
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: olafurpg/setup-scala@v11
         with:
           java-version: zulu@1.11
-      - run: sbt ++{{ matrix.scala }} clean scalafmtSbtCheck scalafmtCheck test doc
+      - run: sbt ++${{ matrix.scala }} clean scalafmtSbtCheck scalafmtCheck test doc
         if: startsWith(matrix.scala, '3')
       - run: sbt ++{{ matrix.scala }} clean scalafmtSbtCheck scalafmtCheck coverage test doc coverageReport coveralls
         if: startsWith(matrix.scala, '2')

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ inThisBuild(
 )
 
 scalaVersion := "2.12.14"
-crossScalaVersions := Seq("2.12.14", "2.13.6")
+crossScalaVersions := Seq("2.12.14", "2.13.6", "3.0.0")
 
 libraryDependencies ++=
   Seq(
@@ -28,11 +28,7 @@ libraryDependencies ++=
     "org.scala-lang.modules"       %% "scala-java8-compat" % "1.0.0",
     "com.google.code.findbugs"      % "jsr305"             % "3.0.2" % "provided",
     "org.scalactic"                %% "scalactic"          % "3.2.9" % "test",
-    "org.scalatest"                %% "scalatest"          % "3.2.9" % "test",
-    compilerPlugin(
-      "com.github.ghik" % "silencer-plugin" % "1.7.5" cross CrossVersion.full
-    ),
-    "com.github.ghik" % "silencer-lib" % "1.7.5" % Provided cross CrossVersion.full
+    "org.scalatest"                %% "scalatest"          % "3.2.9" % "test"
   )
 
 scalafmtOnCompile := true
@@ -94,7 +90,7 @@ scalacOptions ++=
       Nil
   })
 
-scalacOptions in (Compile, console) --= Seq(
+Compile / console / scalacOptions --= Seq(
   "-Ywarn-unused:imports",
   "-Xfatal-warnings"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ inThisBuild(
 )
 
 scalaVersion := "2.12.14"
-crossScalaVersions := Seq("2.12.14", "2.13.6", "3.0.0")
+crossScalaVersions := Seq("2.12.14", "2.13.6", "3.0.1")
 
 libraryDependencies ++=
   Seq(

--- a/src/test/scala/com/github/blemale/scaffeine/ScaffeineSpec.scala
+++ b/src/test/scala/com/github/blemale/scaffeine/ScaffeineSpec.scala
@@ -36,7 +36,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
     "set initial capacity" in {
       val scaffeine = Scaffeine().initialCapacity(99)
 
-      val getInitialCapacity = PrivateMethod[Int]('getInitialCapacity)
+      val getInitialCapacity = PrivateMethod[Int](Symbol("getInitialCapacity"))
       val initialCapacity =
         scaffeine.underlying invokePrivate getInitialCapacity()
 
@@ -46,7 +46,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
     "set executor" in {
       val scaffeine = Scaffeine().executor(ExecutionContext.global)
 
-      val getExecutor = PrivateMethod[Executor]('getExecutor)
+      val getExecutor = PrivateMethod[Executor](Symbol("getExecutor"))
       val executor    = scaffeine.underlying invokePrivate getExecutor()
 
       executor should be(ExecutionContext.global)
@@ -55,7 +55,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
     "set maximum size" in {
       val scaffeine = Scaffeine().maximumSize(99)
 
-      val getMaximumWeight = PrivateMethod[Long]('getMaximum)
+      val getMaximumWeight = PrivateMethod[Long](Symbol("getMaximum"))
       val maximumSize      = scaffeine.underlying invokePrivate getMaximumWeight()
 
       maximumSize should be(99L)
@@ -65,7 +65,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
       val scaffeine =
         Scaffeine().maximumWeight(99).weigher((_: Any, _: Any) => 1)
 
-      val getMaximumWeight = PrivateMethod[Long]('getMaximum)
+      val getMaximumWeight = PrivateMethod[Long](Symbol("getMaximum"))
       val maximumWeight    = scaffeine.underlying invokePrivate getMaximumWeight()
 
       maximumWeight should be(99L)
@@ -74,7 +74,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
     "set weigher" in {
       val scaffeine = Scaffeine().weigher((_: Any, _: Any) => 1)
 
-      val isWeighted = PrivateMethod[Boolean]('isWeighted)
+      val isWeighted = PrivateMethod[Boolean](Symbol("isWeighted"))
       val weighted   = scaffeine.underlying invokePrivate isWeighted()
 
       weighted should be(true)
@@ -83,7 +83,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
     "set weak keys" in {
       val scaffeine = Scaffeine().weakKeys()
 
-      val isStrongKeys = PrivateMethod[Boolean]('isStrongKeys)
+      val isStrongKeys = PrivateMethod[Boolean](Symbol("isStrongKeys"))
       val strongKeys   = scaffeine.underlying invokePrivate isStrongKeys()
 
       strongKeys should be(false)
@@ -92,7 +92,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
     "set weak values" in {
       val scaffeine = Scaffeine().weakValues()
 
-      val isWeakValues = PrivateMethod[Boolean]('isWeakValues)
+      val isWeakValues = PrivateMethod[Boolean](Symbol("isWeakValues"))
       val weakValues   = scaffeine.underlying invokePrivate isWeakValues()
 
       weakValues should be(true)
@@ -101,8 +101,8 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
     "set soft values" in {
       val scaffeine = Scaffeine().softValues()
 
-      val isStrongValues = PrivateMethod[Boolean]('isStrongValues)
-      val isWeakValues   = PrivateMethod[Boolean]('isWeakValues)
+      val isStrongValues = PrivateMethod[Boolean](Symbol("isStrongValues"))
+      val isWeakValues   = PrivateMethod[Boolean](Symbol("isWeakValues"))
 
       val strongValues = scaffeine.underlying invokePrivate isStrongValues()
       val weakValues   = scaffeine.underlying invokePrivate isWeakValues()
@@ -115,7 +115,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
       val scaffeine = Scaffeine().expireAfterWrite(10.minutes)
 
       val getExpiresAfterWriteNanos =
-        PrivateMethod[Long]('getExpiresAfterWriteNanos)
+        PrivateMethod[Long](Symbol("getExpiresAfterWriteNanos"))
       val expiresAfterWriteNanos =
         scaffeine.underlying invokePrivate getExpiresAfterWriteNanos()
 
@@ -126,7 +126,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
       val scaffeine = Scaffeine().expireAfterAccess(10.minutes)
 
       val getExpiresAfterAccessNanos =
-        PrivateMethod[Long]('getExpiresAfterAccessNanos)
+        PrivateMethod[Long](Symbol("getExpiresAfterAccessNanos"))
       val expiresAfterAccessNanos =
         scaffeine.underlying invokePrivate getExpiresAfterAccessNanos()
 
@@ -140,8 +140,9 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
         read = (_: Any, _: Any, _) => 30.minutes
       )
 
-      val getExpiry = PrivateMethod[caffeine.cache.Expiry[Any, Any]]('getExpiry)
-      val expiry    = scaffeine.underlying invokePrivate getExpiry(false)
+      val getExpiry =
+        PrivateMethod[caffeine.cache.Expiry[Any, Any]](Symbol("getExpiry"))
+      val expiry = scaffeine.underlying invokePrivate getExpiry(false)
 
       expiry.expireAfterCreate(null, null, 0) should be(10.minutes.toNanos)
       expiry.expireAfterUpdate(null, null, 0, 0) should be(20.minutes.toNanos)
@@ -152,7 +153,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
       val scaffeine = Scaffeine().refreshAfterWrite(10.minutes)
 
       val getRefreshAfterWriteNanos =
-        PrivateMethod[Long]('getRefreshAfterWriteNanos)
+        PrivateMethod[Long](Symbol("getRefreshAfterWriteNanos"))
       val refreshAfterWriteNanos =
         scaffeine.underlying invokePrivate getRefreshAfterWriteNanos()
 
@@ -162,7 +163,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
     "set ticker" in {
       val scaffeine = Scaffeine().ticker(caffeine.cache.Ticker.disabledTicker())
 
-      val getTicker = PrivateMethod[caffeine.cache.Ticker]('getTicker)
+      val getTicker = PrivateMethod[caffeine.cache.Ticker](Symbol("getTicker"))
       val ticker    = scaffeine.underlying invokePrivate getTicker()
 
       ticker should be(caffeine.cache.Ticker.disabledTicker())
@@ -174,7 +175,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
 
       val getRemovalListener =
         PrivateMethod[caffeine.cache.RemovalListener[Any, Any]](
-          'getRemovalListener
+          Symbol("getRemovalListener")
         )
       val removalListener =
         scaffeine.underlying invokePrivate getRemovalListener(false)
@@ -188,7 +189,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
 
       val getEvictionListener =
         PrivateMethod[caffeine.cache.RemovalListener[Any, Any]](
-          'getEvictionListener
+          Symbol("getEvictionListener")
         )
       val evictionListener =
         scaffeine.underlying invokePrivate getEvictionListener(false)
@@ -199,7 +200,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
     "set record stats" in {
       val scaffeine = Scaffeine().recordStats()
 
-      val isRecordingStats = PrivateMethod[Boolean]('isRecordingStats)
+      val isRecordingStats = PrivateMethod[Boolean](Symbol("isRecordingStats"))
       val recordingStats   = scaffeine.underlying invokePrivate isRecordingStats()
 
       recordingStats should be(true)
@@ -209,7 +210,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
       val scaffeine =
         Scaffeine().recordStats(() => StatsCounter.disabledStatsCounter())
 
-      val isRecordingStats = PrivateMethod[Boolean]('isRecordingStats)
+      val isRecordingStats = PrivateMethod[Boolean](Symbol("isRecordingStats"))
       val recordingStats   = scaffeine.underlying invokePrivate isRecordingStats()
 
       recordingStats should be(true)
@@ -218,7 +219,7 @@ class ScaffeineSpec extends AnyWordSpec with Matchers with PrivateMethodTester {
     "set scheduler" in {
       val scaffeine = Scaffeine().scheduler(Scheduler.systemScheduler())
 
-      val getScheduler = PrivateMethod[Scheduler]('getScheduler)
+      val getScheduler = PrivateMethod[Scheduler](Symbol("getScheduler"))
       val scheduler    = scaffeine.underlying invokePrivate getScheduler()
 
       scheduler should be(Scheduler.systemScheduler())


### PR DESCRIPTION
Changes in detail:
* Add Scala 3.0.0 to build
* Remove superfluous silencer plugin (not needed on 2.12+)
* Adjust to new sbt syntax
* Rewrite `Symbol` syntax to be Scala 3 compatible without special import