### PR TITLE
build.sbt: java 8 compatibility for java sources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ libraryDependencies ++=
 scalafmtOnCompile := true
 
 scalacOptions ++= Seq("-target:jvm-1.8")
+javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
 scalacOptions ++=
   (CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
Using version 5.0.0 or later with java 8 results in an error similar to:
```
java.lang.UnsupportedClassVersionError:
com/github/benmanes/caffeine/cache/Expiry has been compiled by a more
recent version of the Java Runtime (class file version 55.0), this version
of the Java Runtime only recognizes class file versions up to 52.0
```

Where the class file versions map to java version as follows:
* 52 = java 8
* 55 = java 11

As of version 5.1.1, unzipping the jar and checking class versions shows:
```
for f in $(find com -name \*.class); do
  javap -v $f | grep -H --label=$f major
done
com/github/blemale/scaffeine/Cache$.class:  major version: 52
com/github/blemale/scaffeine/Scaffeine$.class:  major version: 52
...
com/github/blemale/scaffeine/CacheLoaderAdapter.class:  major version: 55
com/github/blemale/scaffeine/AsyncCacheLoaderAdapter.class:  major version: 55
```

Note the the setting `scalacOptions ++= Seq("-target:jvm-1.8")` is ensuring
scala sources are compatible with java 8, but `CacheLoaderAdapter` and
`AsyncCacheLoaderAdapter` are built from java sources so the scalac option
has no impact for them.

Add similar `javacOptions` to ensure compatibility with java 8. Afterwards
the java class files show a major version of 52 as well.