### PR TITLE
Replace obsolete Travis CI badge with GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://img.shields.io/travis/blemale/scaffeine/master?style=flat-square)](https://travis-ci.org/blemale/scaffeine.svg?branch=master)
+[![CI](https://github.com/blemale/scaffeine/actions/workflows/ci.yml/badge.svg)](https://github.com/blemale/scaffeine/actions/workflows/ci.yml)
 [![Coverage Status](https://img.shields.io/coveralls/github/blemale/scaffeine/master?style=flat-square)](https://coveralls.io/github/blemale/scaffeine?branch=master)
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.blemale/scaffeine_2.12?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/com.github.blemale/scaffeine_2.12)
 [![License](https://img.shields.io/github/license/blemale/scaffeine?style=flat-square)](http://www.apache.org/licenses/LICENSE-2.0.html)


### PR DESCRIPTION

![image](https://github.com/blemale/scaffeine/assets/52038/c88b196b-c83f-4ce0-94f8-869171daa64b)


https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge