### PR TITLE
Add `apiUrl` definition to `build.sbt`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 inThisBuild(
   List(
-    name         := "scaffeine",
     description  := "Thin Scala wrapper for Caffeine.",
     organization := "com.github.blemale",
     homepage     := Some(url("https://github.com/blemale/scaffeine")),

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,19 @@ inThisBuild(
 scalaVersion       := "2.12.20"
 crossScalaVersions := Seq("2.12.20", "2.13.15", "3.3.5")
 
+apiURL := {
+  val scalaVersionSuffix =
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 12)) => "2.12"
+      case Some((2, 13)) => "2.13"
+      case Some((3, _))  => "3"
+      case _ => throw new RuntimeException("Unsupported Scala version.")
+    }
+  val path      = s"${name.value}_$scalaVersionSuffix"
+  val versionId = version.value.takeWhile(_ != '+')
+  Some(url(s"https://www.javadoc.io/doc/com.github.blemale/$path/$versionId/"))
+}
+
 libraryDependencies ++=
   Seq(
     "com.github.ben-manes.caffeine" % "caffeine" % CaffeineVersion.value,


### PR DESCRIPTION
Adds a [`apiUrl`](https://www.scala-sbt.org/1.x/docs/Howto-Scaladoc.html#Define+the+location+of+API+documentation+for+a+library) definition for the library, pointing to the correct API docs. This was motivated by the need to define `apiMappings` downstream; see https://github.com/adzerk/apso/pull/835 for an example. After this, if users set `autoApiMappings` to true, things should work out of the box.

Opportunistically, I also removed the explicit `name` definition, which is not needed and is inferred by the package name.